### PR TITLE
feat: add 1-click block extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Create an issue if you want a new feature or a PR if you want to add your projec
 - [Save to read later Bot 🔖](https://bsky.app/profile/savetoread.bsky.social) by: [@kr1s](https://github.com/Cristuker)
 - [Open Handles](https://handles.domi.zip/) by: [@slickdomique](https://github.com/SlickDomique)
 - [#bolhadev](https://bsky.app/profile/bolhadev.com) by: [@xburgr](https://bsky.app/profile/did:plc:7mcf3jopjztipcusxgeaj2vy)
+- [1-Click Block](https://github.com/omurilo/bsky-one-click-block) by: [@omurilo.dev](https://bsky.app/profile/omurilo.dev)
 
 ### 🚧 WIP
 


### PR DESCRIPTION
Add a new project to README.md, a `1-Click Bluesky Block - chrome extension`, a extension to add a block button to feed posts.