### PR TITLE
Add OpenPost to Bluesky tools

### DIFF
--- a/README.eng.md
+++ b/README.eng.md
@@ -79,7 +79,7 @@ Place here links of repos with features involving BlueSky that you like!
 | [WhiteWind](https://whtwnd.com/)| / | A blogging platform | / |
 | [BlueMotion](https://www.bluemotion.app/)| / | A video stream plataform | / |
 | [FxBluesky](https://xsky.app)| / | Discord embed generator with video support | [@allanf181](https://github.com/allanf181) |
-| [OpenPost](https://openpost.social)| [Link](https://github.com/rodrgds/openpost) | Open-source, self-hosted tool for preparing and scheduling posts to Bluesky and other social networks | [@rodrgds](https://github.com/rodrgds) |
+| [OpenPost](https://openpo.st)| [Link](https://github.com/getopenpost/openpost) | Open-source, self-hosted tool for preparing and scheduling posts to Bluesky and other social networks | [@rodrgds](https://github.com/rodrgds) |
 
 ### 🆔 Identity
 

--- a/README.eng.md
+++ b/README.eng.md
@@ -79,6 +79,7 @@ Place here links of repos with features involving BlueSky that you like!
 | [WhiteWind](https://whtwnd.com/)| / | A blogging platform | / |
 | [BlueMotion](https://www.bluemotion.app/)| / | A video stream plataform | / |
 | [FxBluesky](https://xsky.app)| / | Discord embed generator with video support | [@allanf181](https://github.com/allanf181) |
+| [OpenPost](https://openpost.social)| [Link](https://github.com/rodrgds/openpost) | Open-source, self-hosted tool for preparing and scheduling posts to Bluesky and other social networks | [@rodrgds](https://github.com/rodrgds) |
 
 ### 🆔 Identity
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Coloque links de repositórios com features que você goste envolvendo o Bluesky
 | [WhiteWind](https://whtwnd.com/)| / | Plataforma de blogging | / |
 | [BlueMotion](https://www.bluemotion.app/)| / |  Plataforma de stream de vídeo | / |
 | [FxBluesky](https://xsky.app)| / | Gerador de embed para o Discord com suporte para video | [@allanf181](https://github.com/allanf181) |
+| [OpenPost](https://openpost.social)| [Link](https://github.com/rodrgds/openpost) | Ferramenta open source e autoalojada para preparar e agendar publicações no Bluesky e noutras redes sociais | [@rodrgds](https://github.com/rodrgds) |
 
 
 ### 🆔 Identidade

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Coloque links de repositórios com features que você goste envolvendo o Bluesky
 | [WhiteWind](https://whtwnd.com/)| / | Plataforma de blogging | / |
 | [BlueMotion](https://www.bluemotion.app/)| / |  Plataforma de stream de vídeo | / |
 | [FxBluesky](https://xsky.app)| / | Gerador de embed para o Discord com suporte para video | [@allanf181](https://github.com/allanf181) |
-| [OpenPost](https://openpost.social)| [Link](https://github.com/rodrgds/openpost) | Ferramenta open source e autoalojada para preparar e agendar publicações no Bluesky e noutras redes sociais | [@rodrgds](https://github.com/rodrgds) |
+| [OpenPost](https://openpo.st)| [Link](https://github.com/getopenpost/openpost) | Ferramenta open source e autoalojada para preparar e agendar publicações no Bluesky e noutras redes sociais | [@rodrgds](https://github.com/rodrgds) |
 
 
 ### 🆔 Identidade


### PR DESCRIPTION
Adds OpenPost to the Tools section in both the Portuguese and English READMEs.

OpenPost is an open-source, self-hosted tool that can prepare and schedule Bluesky posts alongside posts for other networks.

Disclosure: I maintain OpenPost.